### PR TITLE
import the theme name from package.json

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const pkg = require('./package.json');
 
 module.exports = () => ({
   siteMetadata: {
@@ -21,8 +22,7 @@ module.exports = () => ({
     {
       resolve: 'gatsby-plugin-compile-es6-packages',
       options: {
-        // replace with the name of your theme
-        modules: ['gatsby-theme-powerboard'],
+        modules: [pkg.name]
       },
     },
     {


### PR DESCRIPTION
Rather than asking the user to add the theme name, which could be a missed detail, import the name form their package.json instead